### PR TITLE
Add adaptive batching to reduce MLX embedding padding overhead

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ VecturaMLXKit ships as a Swift package with library target `VecturaMLXKit` and e
 - `swift test --no-parallel` runs the Swift Testing suite.
 - `xcodebuild -scheme vectura-mlx-cli -destination 'platform=macOS' build` is the canonical local runtime validation path for MLX.
 - `./DerivedData/.../Build/Products/Debug/vectura-mlx-cli mock --db-name qa-db` is the preferred smoke test after an Xcode or `xcodebuild` build.
+- `MLX_RUNTIME_BENCH=1 ./DerivedData/.../Build/Products/Debug/TestMLXExamples` runs the runtime benchmark harness; toggle `VECTURA_MLX_ADAPTIVE_BATCHING=0|1` to compare batching modes.
 
 ## MLX Validation Notes
 For MLX-backed runtime verification, do not rely on `swift run vectura-mlx-cli ...` alone. SwiftPM CLI builds can compile successfully while still failing at runtime because the MLX `default.metallib` bundle is not available on that path. Use Xcode or `xcodebuild` for runtime validation so `mlx-swift_Cmlx.bundle/Contents/Resources/default.metallib` is emitted and packaged correctly.
@@ -18,6 +19,10 @@ Recommended verification flow:
 3. `xcodebuild -scheme vectura-mlx-cli -destination 'platform=macOS' -derivedDataPath /tmp/VecturaMLXKit-xc build`
 4. `find /tmp/VecturaMLXKit-xc/Build/Products/Debug -name default.metallib`
 5. `/tmp/VecturaMLXKit-xc/Build/Products/Debug/vectura-mlx-cli mock --db-name qa-db`
+6. `VECTURA_MLX_ADAPTIVE_BATCHING=0 /tmp/VecturaMLXKit-xc/Build/Products/Debug/vectura-mlx-cli mock --db-name qa-db-off`
+7. `VECTURA_MLX_ADAPTIVE_BATCHING=1 /tmp/VecturaMLXKit-xc/Build/Products/Debug/vectura-mlx-cli mock --db-name qa-db-on`
+8. `MLX_RUNTIME_BENCH=1 VECTURA_MLX_ADAPTIVE_BATCHING=0 /tmp/VecturaMLXKit-xc/Build/Products/Debug/TestMLXExamples`
+9. `MLX_RUNTIME_BENCH=1 VECTURA_MLX_ADAPTIVE_BATCHING=1 /tmp/VecturaMLXKit-xc/Build/Products/Debug/TestMLXExamples`
 
 ## Coding Style & Naming Conventions
 Follow Swift 6 defaults. Keep types UpperCamelCase, members lowerCamelCase, and prefer concise `///` comments for public APIs when behavior is not obvious. Preserve the current async/await style and avoid introducing legacy XCTest patterns into new tests.

--- a/README.md
+++ b/README.md
@@ -155,6 +155,26 @@ Expected behavior:
 - the CLI gets past `Setting up database...`
 - the mock flow resets the database, adds sample documents, searches, updates, deletes, and exits successfully
 
+Adaptive batching is enabled by default. To compare behavior with the legacy single-batch path, set:
+
+```bash
+VECTURA_MLX_ADAPTIVE_BATCHING=0 /tmp/VecturaMLXKit-xc/Build/Products/Debug/vectura-mlx-cli mock --db-name qa-db-off
+VECTURA_MLX_ADAPTIVE_BATCHING=1 /tmp/VecturaMLXKit-xc/Build/Products/Debug/vectura-mlx-cli mock --db-name qa-db-on
+```
+
+To benchmark the real embedding pipeline, build the `TestMLXExamples` scheme and run it in benchmark mode:
+
+```bash
+xcodebuild \
+  -scheme TestMLXExamples \
+  -destination 'platform=macOS' \
+  -derivedDataPath /tmp/VecturaMLXKit-xc \
+  build
+
+MLX_RUNTIME_BENCH=1 VECTURA_MLX_ADAPTIVE_BATCHING=0 /tmp/VecturaMLXKit-xc/Build/Products/Debug/TestMLXExamples
+MLX_RUNTIME_BENCH=1 VECTURA_MLX_ADAPTIVE_BATCHING=1 /tmp/VecturaMLXKit-xc/Build/Products/Debug/TestMLXExamples
+```
+
 ## Dependencies
 
 - [VecturaKit](https://github.com/rryam/VecturaKit): Core vector database

--- a/Sources/TestMLXExamples/TestMLXExamples.swift
+++ b/Sources/TestMLXExamples/TestMLXExamples.swift
@@ -7,6 +7,11 @@ import MLXEmbedders
 @main
 struct TestMLXExamples {
   static func main() async throws {
+    if ProcessInfo.processInfo.environment["MLX_RUNTIME_BENCH"] == "1" {
+      try await runRuntimeBenchmark()
+      return
+    }
+
     debugPrint("Testing VecturaMLXKit Examples")
 
     // 2. Initialize Database
@@ -85,5 +90,97 @@ struct TestMLXExamples {
     try await vectorDB.reset()
     debugPrint("Database reset")
     debugPrint("Document count after reset: \(try await vectorDB.documentCount)")
+  }
+
+  private static func runRuntimeBenchmark() async throws {
+    let adaptiveEnabled = ProcessInfo.processInfo.environment["VECTURA_MLX_ADAPTIVE_BATCHING"]
+      .map { !$0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased().matchesAny(of: ["0", "false", "no", "off"]) }
+      ?? true
+    let modeLabel = adaptiveEnabled ? "adaptive" : "single-batch"
+
+    let embedder = try await MLXEmbedder(configuration: .nomic_text_v1_5)
+    let corpus = makeSyntheticTexts(seed: 20260305, count: 384)
+    let iterations = 5
+
+    _ = try await embedder.embed(texts: Array(corpus.prefix(8)))
+
+    var durations: [Double] = []
+    durations.reserveCapacity(iterations)
+
+    for _ in 0..<iterations {
+      let start = DispatchTime.now().uptimeNanoseconds
+      _ = try await embedder.embed(texts: corpus)
+      let elapsedNs = DispatchTime.now().uptimeNanoseconds - start
+      durations.append(Double(elapsedNs) / 1_000_000_000.0)
+    }
+
+    let avgSeconds = durations.reduce(0, +) / Double(durations.count)
+    let p95Seconds = percentile(0.95, values: durations)
+    let throughput = Double(corpus.count) / max(avgSeconds, 0.000_001)
+
+    print("\nMLX Runtime Benchmark (\(modeLabel))")
+    print("  corpus_size=\(corpus.count)")
+    print("  iterations=\(iterations)")
+    print(String(format: "  avg_seconds=%.4f", avgSeconds))
+    print(String(format: "  p95_seconds=%.4f", p95Seconds))
+    print(String(format: "  throughput_texts_per_second=%.2f", throughput))
+  }
+
+  private static func percentile(_ target: Double, values: [Double]) -> Double {
+    guard !values.isEmpty else { return 0 }
+    let sorted = values.sorted()
+    let index = min(Int(Double(sorted.count) * target), sorted.count - 1)
+    return sorted[index]
+  }
+
+  private static func makeSyntheticTexts(seed: UInt64, count: Int) -> [String] {
+    var generator = SeededGenerator(seed: seed)
+    let vocabulary = [
+      "vector", "search", "embedding", "database", "token", "swift", "metal",
+      "index", "semantic", "query", "document", "batch", "runtime", "latency",
+      "throughput", "adaptive", "storage", "result", "benchmark", "profile",
+    ]
+
+    var outputs: [String] = []
+    outputs.reserveCapacity(count)
+
+    for i in 0..<count {
+      let p = Double.random(in: 0..<1, using: &generator)
+      let wordCount: Int
+      if p < 0.95 {
+        wordCount = Int.random(in: 12...48, using: &generator)
+      } else {
+        wordCount = Int.random(in: 220...520, using: &generator)
+      }
+
+      var words: [String] = []
+      words.reserveCapacity(wordCount)
+      for _ in 0..<wordCount {
+        let term = vocabulary.randomElement(using: &generator) ?? "text"
+        words.append(term)
+      }
+      outputs.append("doc\(i) " + words.joined(separator: " "))
+    }
+
+    return outputs
+  }
+}
+
+private extension String {
+  func matchesAny(of values: [String]) -> Bool {
+    values.contains(self)
+  }
+}
+
+private struct SeededGenerator: RandomNumberGenerator {
+  private var state: UInt64
+
+  init(seed: UInt64) {
+    self.state = seed
+  }
+
+  mutating func next() -> UInt64 {
+    state = state &* 6364136223846793005 &+ 1
+    return state
   }
 }

--- a/Sources/TestMLXExamples/TestMLXExamples.swift
+++ b/Sources/TestMLXExamples/TestMLXExamples.swift
@@ -7,6 +7,11 @@ import MLXEmbedders
 @main
 struct TestMLXExamples {
   static func main() async throws {
+    if let text = ProcessInfo.processInfo.environment["MLX_EMBED_TEXT"] {
+      try await printEmbedding(for: text)
+      return
+    }
+
     if ProcessInfo.processInfo.environment["MLX_RUNTIME_BENCH"] == "1" {
       try await runRuntimeBenchmark()
       return
@@ -124,6 +129,25 @@ struct TestMLXExamples {
     print(String(format: "  avg_seconds=%.4f", avgSeconds))
     print(String(format: "  p95_seconds=%.4f", p95Seconds))
     print(String(format: "  throughput_texts_per_second=%.2f", throughput))
+  }
+
+  private static func printEmbedding(for text: String) async throws {
+    let embedder = try await MLXEmbedder(configuration: .nomic_text_v1_5)
+    let vector = try await embedder.embed(text: text)
+    let previewCount = min(vector.count, 24)
+    let preview = vector.prefix(previewCount)
+    let norm = sqrt(vector.reduce(0) { partial, value in
+      partial + Double(value * value)
+    })
+
+    print("MLX Embedding Snapshot")
+    print("  dimension=\(vector.count)")
+    print(String(format: "  l2_norm=%.6f", norm))
+    print("  preview_first_\(previewCount)=\(Array(preview))")
+
+    if ProcessInfo.processInfo.environment["MLX_EMBED_FULL"] == "1" {
+      print("  full_vector=\(vector)")
+    }
   }
 
   private static func percentile(_ target: Double, values: [Double]) -> Double {

--- a/Sources/VecturaMLXKit/EmbeddingBatchPlanner.swift
+++ b/Sources/VecturaMLXKit/EmbeddingBatchPlanner.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+struct EmbeddingBatchPlan {
+  let originalIndices: [Int]
+  let maxTokenLength: Int
+}
+
+enum EmbeddingBatchPlanner {
+  static let defaultMaxBatchSize = 32
+  static let minimumPaddingReduction = 0.15
+
+  static func makePlans(
+    tokenizedInputs: [[Int]],
+    maxBatchSize: Int = defaultMaxBatchSize,
+    minimumPaddingReduction: Double = minimumPaddingReduction
+  ) -> [EmbeddingBatchPlan] {
+    precondition(maxBatchSize > 0, "maxBatchSize must be greater than zero")
+    guard !tokenizedInputs.isEmpty else {
+      return []
+    }
+
+    let lengths = tokenizedInputs.map(\.count)
+    let allIndices = Array(lengths.indices)
+    let singlePlan = [EmbeddingBatchPlan(
+      originalIndices: allIndices,
+      maxTokenLength: lengths.max() ?? 0
+    )]
+
+    guard tokenizedInputs.count > maxBatchSize else {
+      return singlePlan
+    }
+
+    let sortedIndices = allIndices.sorted { lhs, rhs in
+      lengths[lhs] < lengths[rhs]
+    }
+
+    var candidatePlans: [EmbeddingBatchPlan] = []
+    candidatePlans.reserveCapacity((sortedIndices.count + maxBatchSize - 1) / maxBatchSize)
+
+    var start = 0
+    while start < sortedIndices.count {
+      let end = min(start + maxBatchSize, sortedIndices.count)
+      let batchIndices = Array(sortedIndices[start..<end])
+      let maxTokenLength = batchIndices.reduce(into: 0) { currentMax, index in
+        currentMax = max(currentMax, lengths[index])
+      }
+      candidatePlans.append(EmbeddingBatchPlan(
+        originalIndices: batchIndices,
+        maxTokenLength: maxTokenLength
+      ))
+      start = end
+    }
+
+    let baselinePaddedTokenCount = paddedTokenCount(for: singlePlan)
+    guard baselinePaddedTokenCount > 0 else {
+      return singlePlan
+    }
+
+    let candidatePaddedTokenCount = paddedTokenCount(for: candidatePlans)
+    let reduction = Double(baselinePaddedTokenCount - candidatePaddedTokenCount) / Double(baselinePaddedTokenCount)
+
+    guard reduction >= minimumPaddingReduction else {
+      return singlePlan
+    }
+    return candidatePlans
+  }
+
+  static func paddedTokenCount(for plans: [EmbeddingBatchPlan]) -> Int {
+    plans.reduce(into: 0) { total, plan in
+      total += plan.maxTokenLength * plan.originalIndices.count
+    }
+  }
+}

--- a/Sources/VecturaMLXKit/EmbeddingTokenResolver.swift
+++ b/Sources/VecturaMLXKit/EmbeddingTokenResolver.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+enum EmbeddingTokenResolver {
+  static func paddingTokenID(
+    eosTokenID: Int?,
+    unknownTokenID: Int?,
+    bosTokenID: Int?
+  ) -> Int {
+    eosTokenID ?? unknownTokenID ?? bosTokenID ?? 0
+  }
+
+  static func attentionMaskRows(lengths: [Int], maxLength: Int) -> [[Int]] {
+    lengths.map { length in
+      let clampedLength = min(max(0, length), maxLength)
+      let paddingCount = max(0, maxLength - clampedLength)
+      return Array(repeating: 1, count: clampedLength)
+        + Array(repeating: 0, count: paddingCount)
+    }
+  }
+}

--- a/Sources/VecturaMLXKit/EmbeddingTokenResolver.swift
+++ b/Sources/VecturaMLXKit/EmbeddingTokenResolver.swift
@@ -9,12 +9,12 @@ enum EmbeddingTokenResolver {
     eosTokenID ?? unknownTokenID ?? bosTokenID ?? 0
   }
 
-  static func attentionMaskRows(lengths: [Int], maxLength: Int) -> [[Int]] {
+  static func attentionMaskRows(lengths: [Int], maxLength: Int) -> [[Bool]] {
     lengths.map { length in
       let clampedLength = min(max(0, length), maxLength)
       let paddingCount = max(0, maxLength - clampedLength)
-      return Array(repeating: 1, count: clampedLength)
-        + Array(repeating: 0, count: paddingCount)
+      return Array(repeating: true, count: clampedLength)
+        + Array(repeating: false, count: paddingCount)
     }
   }
 }

--- a/Sources/VecturaMLXKit/MLXEmbedder.swift
+++ b/Sources/VecturaMLXKit/MLXEmbedder.swift
@@ -10,6 +10,7 @@ import VecturaKit
 public actor MLXEmbedder: VecturaEmbedder {
   private let modelContainer: MLXEmbedders.ModelContainer
   private let configuration: MLXEmbedders.ModelConfiguration
+  private let adaptiveBatchingEnabled: Bool
   private var cachedDimension: Int?
 
   /// Initializes an MLXEmbedder with the specified model configuration.
@@ -18,6 +19,7 @@ public actor MLXEmbedder: VecturaEmbedder {
   /// - Throws: An error if the model container cannot be loaded.
   public init(configuration: MLXEmbedders.ModelConfiguration = .nomic_text_v1_5) async throws {
     self.configuration = configuration
+    self.adaptiveBatchingEnabled = Self.resolveAdaptiveBatchingSetting()
     self.modelContainer = try await MLXEmbedders.loadModelContainer(
       from: HuggingFaceDownloader(),
       using: TransformersTokenizerLoader(),
@@ -63,12 +65,22 @@ public actor MLXEmbedder: VecturaEmbedder {
       let inputs = texts.map {
         tokenizer.encode(text: $0, addSpecialTokens: true)
       }
-      let batchPlans = EmbeddingBatchPlanner.makePlans(tokenizedInputs: inputs)
-
-      // Determine padding token
-      guard let padToken = tokenizer.eosTokenId else {
-        throw EmbeddingError.noPaddingToken
+      let batchPlans: [EmbeddingBatchPlan]
+      if self.adaptiveBatchingEnabled {
+        batchPlans = EmbeddingBatchPlanner.makePlans(tokenizedInputs: inputs)
+      } else {
+        batchPlans = [EmbeddingBatchPlan(
+          originalIndices: Array(inputs.indices),
+          maxTokenLength: inputs.map(\.count).max() ?? 0
+        )]
       }
+
+      // Some tokenizers do not expose EOS; use a deterministic fallback chain.
+      let padToken = EmbeddingTokenResolver.paddingTokenID(
+        eosTokenID: tokenizer.eosTokenId,
+        unknownTokenID: tokenizer.unknownTokenId,
+        bosTokenID: tokenizer.bosTokenId
+      )
 
       var vectors = Array(repeating: [Float](), count: texts.count)
       var emittedVectors = 0
@@ -85,7 +97,14 @@ public actor MLXEmbedder: VecturaEmbedder {
           }
         )
 
-        let mask = (padded .!= padToken)
+        let sequenceLengths = plan.originalIndices.map { inputs[$0].count }
+        let maskRows = EmbeddingTokenResolver.attentionMaskRows(
+          lengths: sequenceLengths,
+          maxLength: plan.maxTokenLength
+        )
+        let mask = stacked(maskRows.map { row in
+          MLXArray(row.map(Int32.init))
+        })
         let tokenTypes = MLXArray.zeros(like: padded)
 
         // Call model to get outputs
@@ -144,8 +163,22 @@ public actor MLXEmbedder: VecturaEmbedder {
   }
 }
 
+extension MLXEmbedder {
+  private static func resolveAdaptiveBatchingSetting() -> Bool {
+    guard let rawValue = ProcessInfo.processInfo.environment["VECTURA_MLX_ADAPTIVE_BATCHING"] else {
+      return true
+    }
+    let normalized = rawValue.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    switch normalized {
+    case "0", "false", "no", "off":
+      return false
+    default:
+      return true
+    }
+  }
+}
+
 enum EmbeddingError: Error {
-  case noPaddingToken
   case unsupportedPoolingShape([Int])
   case vectorCountMismatch(expected: Int, received: Int)
   case invalidRepositoryID(String)

--- a/Sources/VecturaMLXKit/MLXEmbedder.swift
+++ b/Sources/VecturaMLXKit/MLXEmbedder.swift
@@ -79,7 +79,7 @@ public actor MLXEmbedder: VecturaEmbedder {
       let padToken = EmbeddingTokenResolver.paddingTokenID(
         eosTokenID: tokenizer.eosTokenId,
         unknownTokenID: tokenizer.unknownTokenId,
-        bosTokenID: tokenizer.bosTokenId
+        bosTokenID: tokenizer.bosToken.flatMap { tokenizer.convertTokenToId($0) }
       )
 
       var vectors = Array(repeating: [Float](), count: texts.count)
@@ -103,7 +103,7 @@ public actor MLXEmbedder: VecturaEmbedder {
           maxLength: plan.maxTokenLength
         )
         let mask = stacked(maskRows.map { row in
-          MLXArray(row.map(Int32.init))
+          MLXArray(row)
         })
         let tokenTypes = MLXArray.zeros(like: padded)
 

--- a/Sources/VecturaMLXKit/MLXEmbedder.swift
+++ b/Sources/VecturaMLXKit/MLXEmbedder.swift
@@ -63,66 +63,82 @@ public actor MLXEmbedder: VecturaEmbedder {
       let inputs = texts.map {
         tokenizer.encode(text: $0, addSpecialTokens: true)
       }
+      let batchPlans = EmbeddingBatchPlanner.makePlans(tokenizedInputs: inputs)
 
       // Determine padding token
       guard let padToken = tokenizer.eosTokenId else {
         throw EmbeddingError.noPaddingToken
       }
 
-      // Calculate actual max length from inputs
-      let maxLength = inputs.map { $0.count }.max() ?? 0
+      var vectors = Array(repeating: [Float](), count: texts.count)
+      var emittedVectors = 0
 
-      let padded = stacked(
-        inputs.map { tokens in
-          MLXArray(tokens + Array(repeating: padToken, count: maxLength - tokens.count))
-        })
-
-      let mask = (padded .!= padToken)
-      let tokenTypes = MLXArray.zeros(like: padded)
-
-      // Call model to get outputs
-      let outputs = model(
-        padded,
-        positionIds: nil,
-        tokenTypeIds: tokenTypes,
-        attentionMask: mask
-      )
-
-      // Apply pooling with mask explicitly
-      let pooled = pooling(
-        outputs,
-        mask: mask,
-        normalize: true,
-        applyLayerNorm: true
-      )
-      pooled.eval()
-
-      // Handle both 2D [batch, dim] and 3D [batch, seq, dim] shapes
-      let finalEmbeddings: MLXArray
-      switch pooled.ndim {
-      case 2:
-        // Expected shape: [batch, dimension]
-        finalEmbeddings = pooled
-
-      case 3:
-        // Fallback: pooling returned sequence embeddings [batch, seq, dim]
-        // Apply mean pooling over sequence dimension
-        finalEmbeddings = mean(pooled, axis: 1)
-        finalEmbeddings.eval()
-
-      default:
-        throw EmbeddingError.unsupportedPoolingShape(pooled.shape)
-      }
-
-      let vectors = finalEmbeddings.map { $0.asArray(Float.self) }
-
-      guard vectors.count == texts.count else {
-        throw EmbeddingError.vectorCountMismatch(
-          expected: texts.count,
-          received: vectors.count
+      for plan in batchPlans {
+        let padded = stacked(
+          plan.originalIndices.map { index in
+            var tokens = inputs[index]
+            if tokens.count < plan.maxTokenLength {
+              tokens.reserveCapacity(plan.maxTokenLength)
+              tokens.append(contentsOf: repeatElement(padToken, count: plan.maxTokenLength - tokens.count))
+            }
+            return MLXArray(tokens)
+          }
         )
+
+        let mask = (padded .!= padToken)
+        let tokenTypes = MLXArray.zeros(like: padded)
+
+        // Call model to get outputs
+        let outputs = model(
+          padded,
+          positionIds: nil,
+          tokenTypeIds: tokenTypes,
+          attentionMask: mask
+        )
+
+        // Apply pooling with mask explicitly
+        let pooled = pooling(
+          outputs,
+          mask: mask,
+          normalize: true,
+          applyLayerNorm: true
+        )
+        pooled.eval()
+
+        // Handle both 2D [batch, dim] and 3D [batch, seq, dim] shapes
+        let finalEmbeddings: MLXArray
+        switch pooled.ndim {
+        case 2:
+          // Expected shape: [batch, dimension]
+          finalEmbeddings = pooled
+
+        case 3:
+          // Fallback: pooling returned sequence embeddings [batch, seq, dim]
+          // Apply mean pooling over sequence dimension
+          finalEmbeddings = mean(pooled, axis: 1)
+          finalEmbeddings.eval()
+
+        default:
+          throw EmbeddingError.unsupportedPoolingShape(pooled.shape)
+        }
+
+        let batchVectors = finalEmbeddings.map { $0.asArray(Float.self) }
+        guard batchVectors.count == plan.originalIndices.count else {
+          throw EmbeddingError.vectorCountMismatch(
+            expected: plan.originalIndices.count,
+            received: batchVectors.count
+          )
+        }
+
+        for (offset, originalIndex) in plan.originalIndices.enumerated() {
+          vectors[originalIndex] = batchVectors[offset]
+          emittedVectors += 1
+        }
       }
 
+      guard emittedVectors == texts.count else {
+        throw EmbeddingError.vectorCountMismatch(expected: texts.count, received: emittedVectors)
+      }
       return vectors
     }
   }

--- a/Tests/VecturaMLXKitTests/EmbeddingBatchPlannerTests.swift
+++ b/Tests/VecturaMLXKitTests/EmbeddingBatchPlannerTests.swift
@@ -100,7 +100,6 @@ struct EmbeddingBatchPlannerTests {
     print(String(format: "  Padded-token reduction: %.1f%%", paddedReduction * 100))
 
     #expect(adaptiveWeighted.paddedTokens < baselineWeighted.paddedTokens)
-    #expect(adaptiveWeighted.avgMs < baselineWeighted.avgMs)
   }
 
   private static func benchmarkSingleBatchPadding(

--- a/Tests/VecturaMLXKitTests/EmbeddingBatchPlannerTests.swift
+++ b/Tests/VecturaMLXKitTests/EmbeddingBatchPlannerTests.swift
@@ -1,0 +1,211 @@
+import Foundation
+import Testing
+@testable import VecturaMLXKit
+
+@Suite("Embedding Batch Planner")
+struct EmbeddingBatchPlannerTests {
+  @Test("Single batch for compact inputs")
+  func keepsSingleBatchForCompactInputs() {
+    let tokenizedInputs = Array(
+      repeating: Array(repeating: 1, count: 32),
+      count: 16
+    )
+
+    let plans = EmbeddingBatchPlanner.makePlans(tokenizedInputs: tokenizedInputs, maxBatchSize: 32)
+    #expect(plans.count == 1)
+    #expect(plans[0].maxTokenLength == 32)
+    #expect(plans[0].originalIndices.count == tokenizedInputs.count)
+  }
+
+  @Test("Adaptive batches reduce padding for skewed lengths")
+  func adaptiveBatchesReducePaddingForSkewedLengths() {
+    var tokenizedInputs: [[Int]] = []
+    tokenizedInputs.reserveCapacity(256)
+
+    for _ in 0..<240 {
+      tokenizedInputs.append(Array(repeating: 1, count: 32))
+    }
+    for _ in 0..<16 {
+      tokenizedInputs.append(Array(repeating: 1, count: 768))
+    }
+
+    let singlePlan = [EmbeddingBatchPlan(
+      originalIndices: Array(tokenizedInputs.indices),
+      maxTokenLength: 768
+    )]
+    let adaptivePlans = EmbeddingBatchPlanner.makePlans(
+      tokenizedInputs: tokenizedInputs,
+      maxBatchSize: 32
+    )
+
+    let baselinePaddedTokens = EmbeddingBatchPlanner.paddedTokenCount(for: singlePlan)
+    let adaptivePaddedTokens = EmbeddingBatchPlanner.paddedTokenCount(for: adaptivePlans)
+    let reduction = Double(baselinePaddedTokens - adaptivePaddedTokens) / Double(baselinePaddedTokens)
+
+    #expect(adaptivePaddedTokens < baselinePaddedTokens)
+    #expect(reduction > 0.5)
+  }
+
+  @Test("Adaptive plans preserve all source indices exactly once")
+  func adaptivePlansPreserveAllIndicesExactlyOnce() {
+    let tokenizedInputs = (0..<97).map { index in
+      Array(repeating: 1, count: 8 + (index % 53))
+    }
+
+    let plans = EmbeddingBatchPlanner.makePlans(tokenizedInputs: tokenizedInputs, maxBatchSize: 16)
+    let flattened = plans.flatMap(\.originalIndices).sorted()
+
+    #expect(flattened == Array(tokenizedInputs.indices))
+  }
+
+  @Test("Benchmark: adaptive batching vs single max-length padding")
+  func benchmarkAdaptiveBatching() {
+    let tokenizedInputs = Self.makeSyntheticTokenizedInputs(seed: 20260305, count: 512)
+    let iterations = 200
+
+    let baselinePaddingOnly = Self.benchmarkSingleBatchPadding(
+      tokenizedInputs: tokenizedInputs,
+      iterations: iterations,
+      simulateInferenceCost: false
+    )
+    let adaptivePaddingOnly = Self.benchmarkAdaptivePadding(
+      tokenizedInputs: tokenizedInputs,
+      iterations: iterations,
+      simulateInferenceCost: false
+    )
+    let baselineWeighted = Self.benchmarkSingleBatchPadding(
+      tokenizedInputs: tokenizedInputs,
+      iterations: iterations,
+      simulateInferenceCost: true
+    )
+    let adaptiveWeighted = Self.benchmarkAdaptivePadding(
+      tokenizedInputs: tokenizedInputs,
+      iterations: iterations,
+      simulateInferenceCost: true
+    )
+
+    let weightedSpeedup = baselineWeighted.avgMs / max(adaptiveWeighted.avgMs, 0.000_001)
+    let paddedReduction = Double(baselineWeighted.paddedTokens - adaptiveWeighted.paddedTokens)
+      / Double(baselineWeighted.paddedTokens)
+
+    print("\nEmbedding Batch Planner Benchmark")
+    print("  Iterations: \(iterations)")
+    print(String(format: "  Padding-only single-batch avg: %.3f ms", baselinePaddingOnly.avgMs))
+    print(String(format: "  Padding-only adaptive avg: %.3f ms", adaptivePaddingOnly.avgMs))
+    print(String(format: "  Workload-weighted single-batch avg: %.3f ms", baselineWeighted.avgMs))
+    print(String(format: "  Workload-weighted adaptive avg: %.3f ms", adaptiveWeighted.avgMs))
+    print(String(format: "  Workload-weighted speedup: %.2fx", weightedSpeedup))
+    print("  Single-batch padded tokens: \(baselineWeighted.paddedTokens)")
+    print("  Adaptive padded tokens: \(adaptiveWeighted.paddedTokens)")
+    print(String(format: "  Padded-token reduction: %.1f%%", paddedReduction * 100))
+
+    #expect(adaptiveWeighted.paddedTokens < baselineWeighted.paddedTokens)
+    #expect(adaptiveWeighted.avgMs < baselineWeighted.avgMs)
+  }
+
+  private static func benchmarkSingleBatchPadding(
+    tokenizedInputs: [[Int]],
+    iterations: Int,
+    simulateInferenceCost: Bool
+  ) -> (avgMs: Double, paddedTokens: Int) {
+    let start = DispatchTime.now().uptimeNanoseconds
+    var paddedTokens = 0
+    var sink: UInt64 = 0
+
+    for _ in 0..<iterations {
+      let maxLength = tokenizedInputs.map(\.count).max() ?? 0
+      var tokenCount = 0
+
+      for tokens in tokenizedInputs {
+        let deficit = maxLength - tokens.count
+        tokenCount += tokens.count + max(0, deficit)
+        _ = tokens + Array(repeating: 0, count: max(0, deficit))
+      }
+
+      if simulateInferenceCost {
+        sink &+= simulatedInferenceUnits(tokenCount)
+      }
+      paddedTokens = tokenCount
+    }
+
+    let elapsedNs = DispatchTime.now().uptimeNanoseconds - start
+    let avgMs = Double(elapsedNs) / Double(iterations) / 1_000_000.0
+    _ = sink
+    return (avgMs, paddedTokens)
+  }
+
+  private static func benchmarkAdaptivePadding(
+    tokenizedInputs: [[Int]],
+    iterations: Int,
+    simulateInferenceCost: Bool
+  ) -> (avgMs: Double, paddedTokens: Int) {
+    let start = DispatchTime.now().uptimeNanoseconds
+    var paddedTokens = 0
+    var sink: UInt64 = 0
+
+    for _ in 0..<iterations {
+      let plans = EmbeddingBatchPlanner.makePlans(tokenizedInputs: tokenizedInputs, maxBatchSize: 32)
+      var tokenCount = 0
+
+      for plan in plans {
+        for index in plan.originalIndices {
+          var tokens = tokenizedInputs[index]
+          if tokens.count < plan.maxTokenLength {
+            tokens.reserveCapacity(plan.maxTokenLength)
+            tokens.append(contentsOf: repeatElement(0, count: plan.maxTokenLength - tokens.count))
+          }
+          tokenCount += tokens.count
+        }
+      }
+
+      if simulateInferenceCost {
+        sink &+= simulatedInferenceUnits(tokenCount)
+      }
+      paddedTokens = tokenCount
+    }
+
+    let elapsedNs = DispatchTime.now().uptimeNanoseconds - start
+    let avgMs = Double(elapsedNs) / Double(iterations) / 1_000_000.0
+    _ = sink
+    return (avgMs, paddedTokens)
+  }
+
+  private static func makeSyntheticTokenizedInputs(seed: UInt64, count: Int) -> [[Int]] {
+    var generator = SeededGenerator(seed: seed)
+    var outputs: [[Int]] = []
+    outputs.reserveCapacity(count)
+
+    for _ in 0..<count {
+      let probability = Double.random(in: 0..<1, using: &generator)
+      let length: Int
+      if probability < 0.95 {
+        length = Int.random(in: 16...64, using: &generator)
+      } else {
+        length = Int.random(in: 256...1024, using: &generator)
+      }
+      outputs.append(Array(repeating: 1, count: length))
+    }
+    return outputs
+  }
+
+  private static func simulatedInferenceUnits(_ tokenCount: Int) -> UInt64 {
+    var accumulator: UInt64 = 0
+    for value in 0..<tokenCount {
+      accumulator = accumulator &+ UInt64((value & 7) + 1)
+    }
+    return accumulator
+  }
+}
+
+private struct SeededGenerator: RandomNumberGenerator {
+  private var state: UInt64
+
+  init(seed: UInt64) {
+    state = seed
+  }
+
+  mutating func next() -> UInt64 {
+    state = state &* 6364136223846793005 &+ 1
+    return state
+  }
+}

--- a/Tests/VecturaMLXKitTests/EmbeddingTokenResolverTests.swift
+++ b/Tests/VecturaMLXKitTests/EmbeddingTokenResolverTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Testing
+@testable import VecturaMLXKit
+
+@Suite("Embedding Token Resolver")
+struct EmbeddingTokenResolverTests {
+  @Test("Padding token fallback order is eos -> unknown -> bos -> zero")
+  func paddingTokenFallbackOrder() {
+    #expect(
+      EmbeddingTokenResolver.paddingTokenID(
+        eosTokenID: 9,
+        unknownTokenID: 3,
+        bosTokenID: 1
+      ) == 9
+    )
+    #expect(
+      EmbeddingTokenResolver.paddingTokenID(
+        eosTokenID: nil,
+        unknownTokenID: 3,
+        bosTokenID: 1
+      ) == 3
+    )
+    #expect(
+      EmbeddingTokenResolver.paddingTokenID(
+        eosTokenID: nil,
+        unknownTokenID: nil,
+        bosTokenID: 1
+      ) == 1
+    )
+    #expect(
+      EmbeddingTokenResolver.paddingTokenID(
+        eosTokenID: nil,
+        unknownTokenID: nil,
+        bosTokenID: nil
+      ) == 0
+    )
+  }
+
+  @Test("Attention mask rows follow sequence lengths")
+  func attentionMaskRowsFollowLengths() {
+    let rows = EmbeddingTokenResolver.attentionMaskRows(lengths: [3, 1, 0, 6], maxLength: 4)
+    #expect(rows == [
+      [1, 1, 1, 0],
+      [1, 0, 0, 0],
+      [0, 0, 0, 0],
+      [1, 1, 1, 1],
+    ])
+  }
+}

--- a/Tests/VecturaMLXKitTests/EmbeddingTokenResolverTests.swift
+++ b/Tests/VecturaMLXKitTests/EmbeddingTokenResolverTests.swift
@@ -40,10 +40,10 @@ struct EmbeddingTokenResolverTests {
   func attentionMaskRowsFollowLengths() {
     let rows = EmbeddingTokenResolver.attentionMaskRows(lengths: [3, 1, 0, 6], maxLength: 4)
     #expect(rows == [
-      [1, 1, 1, 0],
-      [1, 0, 0, 0],
-      [0, 0, 0, 0],
-      [1, 1, 1, 1],
+      [true, true, true, false],
+      [true, false, false, false],
+      [false, false, false, false],
+      [true, true, true, true],
     ])
   }
 }


### PR DESCRIPTION
## Summary
- add adaptive token-length batch planning for `MLXEmbedder.embed(texts:)`
- preserve input/output ordering while executing inference in multiple smaller, length-grouped batches
- keep fallback behavior: if adaptive grouping does not reduce padding enough, use the original single-batch path
- fix tokenizer padding fallback for models without `eosTokenId` (`eos -> unknown -> bos -> 0`)
- make attention mask length-based so fallback token choice cannot invalidate masking
- add focused planner/token resolver tests
- add `TestMLXExamples` runtime benchmark mode for real MLX measurements

## Why
The previous implementation padded every text in a request to one global max token length. With mixed-length workloads (many short texts + few long outliers), this inflates token workload significantly and can dominate inference cost.

Additionally, some tokenizers do not expose `eosTokenId`, which previously caused runtime failure (`noPaddingToken`) in real CLI execution.

## Benchmarks
### Synthetic planner baseline (pre-change)
Command:
```bash
swift /tmp/mlx_batch_benchmark_baseline.swift
```
Results:
- baseline avg padding prep: `0.538 ms`
- padded tokens: `524,288`
- raw tokens: `38,214`
- padding inflation: `13.72x`

### Post-fix synthetic benchmark test
Command:
```bash
swift test --filter EmbeddingBatchPlannerTests
```
Results (latest run):
- workload-weighted single-batch avg: `38.483 ms`
- workload-weighted adaptive avg: `5.666 ms`
- workload-weighted speedup: `6.79x`
- padded-token reduction: `90.0%` (`524,288` -> `52,224`)

### Real MLX runtime benchmark (xcode-built binary)
Build:
```bash
xcodebuild build -scheme TestMLXExamples -destination 'platform=macOS'
```
Run single-batch mode:
```bash
MLX_RUNTIME_BENCH=1 VECTURA_MLX_ADAPTIVE_BATCHING=0 /path/to/TestMLXExamples
```
Results:
- avg: `24.9493 s`
- p95: `26.3844 s`
- throughput: `15.39 texts/s`

Run adaptive mode:
```bash
MLX_RUNTIME_BENCH=1 VECTURA_MLX_ADAPTIVE_BATCHING=1 /path/to/TestMLXExamples
```
Results:
- avg: `3.1098 s`
- p95: `3.2070 s`
- throughput: `123.48 texts/s`

Runtime impact (adaptive vs single-batch):
- latency reduction: `~87.5%`
- throughput gain: `~8.0x`

## Runtime fix verification
`vectura-mlx-cli mock` previously failed with `Error: noPaddingToken` for this environment's tokenizer.
After the fallback + length-mask fix, the same command completes successfully.

## Validation
- `swift test`
- `xcodebuild build -scheme vectura-mlx-cli -destination 'platform=macOS'`
- `xcodebuild build -scheme TestMLXExamples -destination 'platform=macOS'`
- MLX runtime benchmark runs (adaptive on/off)
