### PR TITLE
[codex] Raise platform minimums for VecturaKit 5

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,10 +7,10 @@ let package = Package(
   name: "VecturaMLXKit",
   platforms: [
     .macOS(.v15),
-    .iOS(.v17),
-    .tvOS(.v17),
-    .visionOS(.v1),
-    .watchOS(.v10),
+    .iOS(.v18),
+    .tvOS(.v18),
+    .visionOS(.v2),
+    .watchOS(.v11),
   ],
   products: [
     .library(
@@ -23,7 +23,7 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(url: "https://github.com/rryam/VecturaKit.git", from: "4.0.0"),
+    .package(url: "https://github.com/rryam/VecturaKit.git", from: "5.0.0"),
     .package(url: "https://github.com/ml-explore/mlx-swift-lm/", from: "2.30.3"),
     .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.4.0"),
   ],

--- a/README.md
+++ b/README.md
@@ -5,10 +5,11 @@ MLX-based embeddings for [VecturaKit](https://github.com/rryam/VecturaKit) — G
 <p align="center">
   <img src="https://img.shields.io/badge/Swift-6.0+-fa7343?style=flat&logo=swift&logoColor=white" alt="Swift 6.0+">
   <br>
-  <img src="https://img.shields.io/badge/iOS-17.0+-000000?style=flat&logo=apple&logoColor=white" alt="iOS 17.0+">
-  <img src="https://img.shields.io/badge/macOS-14.0+-000000?style=flat&logo=apple&logoColor=white" alt="macOS 14.0+">
-  <img src="https://img.shields.io/badge/tvOS-17.0+-000000?style=flat&logo=apple&logoColor=white" alt="tvOS 17.0+">
-  <img src="https://img.shields.io/badge/visionOS-1.0+-000000?style=flat&logo=apple&logoColor=white" alt="visionOS 1.0+">
+  <img src="https://img.shields.io/badge/iOS-18.0+-000000?style=flat&logo=apple&logoColor=white" alt="iOS 18.0+">
+  <img src="https://img.shields.io/badge/macOS-15.0+-000000?style=flat&logo=apple&logoColor=white" alt="macOS 15.0+">
+  <img src="https://img.shields.io/badge/tvOS-18.0+-000000?style=flat&logo=apple&logoColor=white" alt="tvOS 18.0+">
+  <img src="https://img.shields.io/badge/visionOS-2.0+-000000?style=flat&logo=apple&logoColor=white" alt="visionOS 2.0+">
+  <img src="https://img.shields.io/badge/watchOS-11.0+-000000?style=flat&logo=apple&logoColor=white" alt="watchOS 11.0+">
 </p>
 
 ## Overview
@@ -23,10 +24,13 @@ Add both VecturaKit and VecturaMLXKit to your `Package.swift`:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/rryam/VecturaKit.git", from: "3.0.0"),
-    .package(url: "https://github.com/rryam/VecturaMLXKit.git", from: "1.0.0"),
+    .package(url: "https://github.com/rryam/VecturaKit.git", from: "5.0.0"),
+    .package(url: "https://github.com/rryam/VecturaMLXKit.git", from: "2.0.0"),
 ],
 ```
+
+`VecturaMLXKit` 2.x tracks the `VecturaKit` 5.x release line and shares the same minimum deployment targets:
+macOS 15, iOS 18, tvOS 18, visionOS 2, and watchOS 11.
 
 Or add them via Xcode's **File > Add Package Dependencies** UI — no special configuration needed.
 


### PR DESCRIPTION
## Summary
- raise `VecturaMLXKit` minimum deployment targets to match the `VecturaKit` 5.x floor
- move the package dependency from `VecturaKit` 4.x to the 5.x release line
- update the README badges and installation instructions for the 2.x compatibility story

## Why
`VecturaMLXKit` 1.x still targets the `VecturaKit` 4.x line, which makes the latest package combination inconsistent for downstream consumers. This draft updates the MLX package for the intended 2.x release line aligned with `VecturaKit` 5.x.

Fixes #3

## Blocker
This PR is intentionally draft until `VecturaKit` ships a new 5.x tag with stable dependency pins.

Upstream prerequisite: [rryam/VecturaKit#80](https://github.com/rryam/VecturaKit/pull/80)

Today, `swift package resolve` fails here because the existing `VecturaKit` 5.x tags still depend on `swift-embeddings` via an unstable branch requirement, and SwiftPM rejects that for downstream stable-version consumers.

## Impact
- `VecturaMLXKit` 2.x will align with `VecturaKit` 5.x once the next 5.x tag is available
- deployment targets will match across both packages: macOS 15, iOS 18, tvOS 18, visionOS 2, watchOS 11
- README installation guidance will match the new major-version pairing

## Validation
- reviewed package and README updates locally
- attempted `swift package resolve` and confirmed it is currently blocked by the upstream `VecturaKit` 5.x release metadata described above
