### PR TITLE
Update MLXEmbedder for current mlx-swift-lm loading API

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(url: "https://github.com/subsriram/VecturaKit.git", branch: "codex/add-vectura-oai-kit"),
+    .package(url: "https://github.com/rryam/VecturaKit.git", from: "5.0.0"),
     .package(url: "https://github.com/ml-explore/mlx-swift-lm/", branch: "main"),
     .package(url: "https://github.com/huggingface/swift-transformers", from: "1.3.0"),
     .package(url: "https://github.com/huggingface/swift-huggingface.git", from: "0.9.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,6 @@ let package = Package(
       dependencies: [
         .product(name: "VecturaKit", package: "VecturaKit"),
         .product(name: "MLXEmbedders", package: "mlx-swift-lm"),
-        .product(name: "MLXHuggingFace", package: "mlx-swift-lm"),
         .product(name: "MLXLMCommon", package: "mlx-swift-lm"),
         .product(name: "Tokenizers", package: "swift-transformers"),
         .product(name: "HuggingFace", package: "swift-huggingface"),

--- a/Package.swift
+++ b/Package.swift
@@ -23,8 +23,10 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(url: "https://github.com/rryam/VecturaKit.git", from: "5.0.0"),
-    .package(url: "https://github.com/ml-explore/mlx-swift-lm/", from: "2.30.3"),
+    .package(url: "https://github.com/subsriram/VecturaKit.git", branch: "codex/add-vectura-oai-kit"),
+    .package(url: "https://github.com/ml-explore/mlx-swift-lm/", branch: "main"),
+    .package(url: "https://github.com/huggingface/swift-transformers", from: "1.3.0"),
+    .package(url: "https://github.com/huggingface/swift-huggingface.git", from: "0.9.0"),
     .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.4.0"),
   ],
   targets: [
@@ -33,6 +35,10 @@ let package = Package(
       dependencies: [
         .product(name: "VecturaKit", package: "VecturaKit"),
         .product(name: "MLXEmbedders", package: "mlx-swift-lm"),
+        .product(name: "MLXHuggingFace", package: "mlx-swift-lm"),
+        .product(name: "MLXLMCommon", package: "mlx-swift-lm"),
+        .product(name: "Tokenizers", package: "swift-transformers"),
+        .product(name: "HuggingFace", package: "swift-huggingface"),
       ]
     ),
     .executableTarget(

--- a/Sources/VecturaMLXKit/MLXEmbedder.swift
+++ b/Sources/VecturaMLXKit/MLXEmbedder.swift
@@ -2,7 +2,6 @@ import Foundation
 import HuggingFace
 import MLX
 import MLXEmbedders
-import MLXHuggingFace
 import MLXLMCommon
 import Tokenizers
 import VecturaKit
@@ -20,8 +19,8 @@ public actor MLXEmbedder: VecturaEmbedder {
   public init(configuration: MLXEmbedders.ModelConfiguration = .nomic_text_v1_5) async throws {
     self.configuration = configuration
     self.modelContainer = try await MLXEmbedders.loadModelContainer(
-      from: #hubDownloader(),
-      using: #huggingFaceTokenizerLoader(),
+      from: HuggingFaceDownloader(),
+      using: TransformersTokenizerLoader(),
       configuration: configuration
     )
   }
@@ -133,4 +132,85 @@ enum EmbeddingError: Error {
   case noPaddingToken
   case unsupportedPoolingShape([Int])
   case vectorCountMismatch(expected: Int, received: Int)
+  case invalidRepositoryID(String)
+}
+
+private struct HuggingFaceDownloader: MLXLMCommon.Downloader {
+  private let client: HubClient
+
+  init(client: HubClient = .default) {
+    self.client = client
+  }
+
+  func download(
+    id: String,
+    revision: String?,
+    matching patterns: [String],
+    useLatest _: Bool,
+    progressHandler: @Sendable @escaping (Progress) -> Void
+  ) async throws -> URL {
+    guard let repoID = HuggingFace.Repo.ID(rawValue: id) else {
+      throw EmbeddingError.invalidRepositoryID(id)
+    }
+
+    return try await client.downloadSnapshot(
+      of: repoID,
+      revision: revision ?? "main",
+      matching: patterns,
+      progressHandler: { @MainActor progress in
+        progressHandler(progress)
+      }
+    )
+  }
+}
+
+private struct TransformersTokenizerLoader: MLXLMCommon.TokenizerLoader {
+  func load(from directory: URL) async throws -> any MLXLMCommon.Tokenizer {
+    let upstream = try await AutoTokenizer.from(modelFolder: directory)
+    return HuggingFaceTokenizerBridge(upstream)
+  }
+}
+
+private struct HuggingFaceTokenizerBridge: MLXLMCommon.Tokenizer {
+  private let upstream: any Tokenizers.Tokenizer
+
+  init(_ upstream: any Tokenizers.Tokenizer) {
+    self.upstream = upstream
+  }
+
+  func encode(text: String, addSpecialTokens: Bool) -> [Int] {
+    upstream.encode(text: text, addSpecialTokens: addSpecialTokens)
+  }
+
+  func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
+    upstream.decode(tokens: tokenIds, skipSpecialTokens: skipSpecialTokens)
+  }
+
+  func convertTokenToId(_ token: String) -> Int? {
+    upstream.convertTokenToId(token)
+  }
+
+  func convertIdToToken(_ id: Int) -> String? {
+    upstream.convertIdToToken(id)
+  }
+
+  var bosToken: String? { upstream.bosToken }
+  var eosToken: String? { upstream.eosToken }
+  var unknownToken: String? { upstream.unknownToken }
+
+  func applyChatTemplate(
+    messages: [[String: any Sendable]],
+    tools: [[String: any Sendable]]?,
+    additionalContext: [String: any Sendable]?
+  ) throws -> [Int] {
+    do {
+      return try upstream.applyChatTemplate(
+        messages: messages,
+        tools: tools,
+        additionalContext: additionalContext
+      )
+    } catch Tokenizers.TokenizerError.missingChatTemplate {
+      throw MLXLMCommon.TokenizerError.missingChatTemplate
+    }
+  }
 }

--- a/Sources/VecturaMLXKit/MLXEmbedder.swift
+++ b/Sources/VecturaMLXKit/MLXEmbedder.swift
@@ -1,21 +1,29 @@
 import Foundation
+import HuggingFace
 import MLX
 import MLXEmbedders
+import MLXHuggingFace
+import MLXLMCommon
+import Tokenizers
 import VecturaKit
 
 /// An embedder implementation using MLX library for generating vector embeddings.
 public actor MLXEmbedder: VecturaEmbedder {
-  private let modelContainer: ModelContainer
-  private let configuration: ModelConfiguration
+  private let modelContainer: MLXEmbedders.ModelContainer
+  private let configuration: MLXEmbedders.ModelConfiguration
   private var cachedDimension: Int?
 
   /// Initializes an MLXEmbedder with the specified model configuration.
   ///
   /// - Parameter configuration: The MLX model configuration to use. Defaults to `.nomic_text_v1_5`.
   /// - Throws: An error if the model container cannot be loaded.
-  public init(configuration: ModelConfiguration = .nomic_text_v1_5) async throws {
+  public init(configuration: MLXEmbedders.ModelConfiguration = .nomic_text_v1_5) async throws {
     self.configuration = configuration
-    self.modelContainer = try await MLXEmbedders.loadModelContainer(configuration: configuration)
+    self.modelContainer = try await MLXEmbedders.loadModelContainer(
+      from: #hubDownloader(),
+      using: #huggingFaceTokenizerLoader(),
+      configuration: configuration
+    )
   }
 
   /// The dimensionality of the embedding vectors produced by this embedder.


### PR DESCRIPTION
## Summary
- update `MLXEmbedder` to the current `mlx-swift-lm` loading API that requires explicit `from:` and `using:` arguments
- replace the old default-loading path with direct Hugging Face downloader and tokenizer loader integration
- remove reliance on the macro-based Hugging Face convenience path and keep the package pointed at upstream `rryam/VecturaKit`

## Details
`mlx-swift-lm` introduced breaking loading API changes that removed the old default hub/tokenizer path. This package was still calling `MLXEmbedders.loadModelContainer(configuration:)`, which no longer compiles against current `main`.

This change updates `VecturaMLXKit` to:
- add the required `HuggingFace`, `Tokenizers`, and `MLXLMCommon` dependencies
- load the model container via explicit downloader/tokenizer bridge types
- keep the rest of the embedder behavior unchanged

## Verification
- `swift build`
