### PR TITLE
[codex] Update MLX integration for latest mlx-swift-lm

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -139,10 +139,10 @@
     {
       "identity" : "vecturakit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/subsriram/VecturaKit.git",
+      "location" : "https://github.com/rryam/VecturaKit.git",
       "state" : {
         "branch" : "main",
-        "revision" : "61df44721fd1ae5fdf4ceff94e6b87d9923a1449"
+        "revision" : "66928a30ae5582c57fd98947040fde91e9004813"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "f503501adb9cabaa4d243b9546fc5b7cb379bf31866a7313ebb3c1b6f073612b",
+  "originHash" : "d6ec5e5a0282e2f95cdc0b47656f8519b90f3512e0e30302268b9b98cd61eb82",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/rryam/VecturaKit.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "66928a30ae5582c57fd98947040fde91e9004813"
+        "revision" : "66928a30ae5582c57fd98947040fde91e9004813",
+        "version" : "6.0.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -25,7 +25,7 @@
       "location" : "https://github.com/ml-explore/mlx-swift-lm/",
       "state" : {
         "branch" : "main",
-        "revision" : "8c9dd6391139242261bcf27d253c326f9cf2d567"
+        "revision" : "7e2b7107be52ffbfe488f3c7987d3f52c1858b4b"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "1fe6fc1f01b3be7f68c806e777648dd5091be24c34d58918b625e6897f737591",
+  "originHash" : "f503501adb9cabaa4d243b9546fc5b7cb379bf31866a7313ebb3c1b6f073612b",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -74,15 +74,6 @@
       }
     },
     {
-      "identity" : "swift-embeddings",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/jkrukowski/swift-embeddings.git",
-      "state" : {
-        "revision" : "66994e3b3ed172a9b691b59d11bd0702c3f5eb33",
-        "version" : "0.0.26"
-      }
-    },
-    {
       "identity" : "swift-huggingface",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-huggingface.git",
@@ -119,24 +110,6 @@
       }
     },
     {
-      "identity" : "swift-safetensors",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/jkrukowski/swift-safetensors.git",
-      "state" : {
-        "revision" : "d249ae40bdea0db5e725d86c84a74d5eaf0e0e8f",
-        "version" : "0.1.0"
-      }
-    },
-    {
-      "identity" : "swift-sentencepiece",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/jkrukowski/swift-sentencepiece",
-      "state" : {
-        "revision" : "36a8b2b45733f6adb3092100f16e4c7d38a10a7c",
-        "version" : "0.0.6"
-      }
-    },
-    {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax.git",
@@ -155,21 +128,21 @@
       }
     },
     {
-      "identity" : "swift-transformers",
+      "identity" : "swift-tokenizers",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/huggingface/swift-transformers",
+      "location" : "https://github.com/DePasqualeOrg/swift-tokenizers.git",
       "state" : {
-        "revision" : "b38443e44d93eca770f2eb68e2a4d0fa100f9aa2",
-        "version" : "1.3.0"
+        "branch" : "main",
+        "revision" : "c0776db53dc722f53b5538f3594ed7a3904db820"
       }
     },
     {
       "identity" : "vecturakit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/rryam/VecturaKit.git",
+      "location" : "https://github.com/subsriram/VecturaKit.git",
       "state" : {
-        "revision" : "55f1489dcc3baaa47dde6cfc4127ba827f39c4fd",
-        "version" : "5.2.1"
+        "branch" : "main",
+        "revision" : "61df44721fd1ae5fdf4ceff94e6b87d9923a1449"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -23,9 +23,9 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(url: "https://github.com/rryam/VecturaKit.git", from: "5.0.0"),
+    .package(url: "https://github.com/subsriram/VecturaKit.git", branch: "main"),
     .package(url: "https://github.com/ml-explore/mlx-swift-lm/", branch: "main"),
-    .package(url: "https://github.com/huggingface/swift-transformers", from: "1.3.0"),
+    .package(url: "https://github.com/DePasqualeOrg/swift-tokenizers.git", branch: "main"),
     .package(url: "https://github.com/huggingface/swift-huggingface.git", from: "0.9.0"),
     .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.4.0"),
   ],
@@ -36,7 +36,7 @@ let package = Package(
         .product(name: "VecturaKit", package: "VecturaKit"),
         .product(name: "MLXEmbedders", package: "mlx-swift-lm"),
         .product(name: "MLXLMCommon", package: "mlx-swift-lm"),
-        .product(name: "Tokenizers", package: "swift-transformers"),
+        .product(name: "Tokenizers", package: "swift-tokenizers"),
         .product(name: "HuggingFace", package: "swift-huggingface"),
       ]
     ),

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(url: "https://github.com/rryam/VecturaKit.git", branch: "main"),
+    .package(url: "https://github.com/rryam/VecturaKit.git", from: "6.0.0"),
     .package(url: "https://github.com/ml-explore/mlx-swift-lm/", branch: "main"),
     .package(url: "https://github.com/DePasqualeOrg/swift-tokenizers.git", branch: "main"),
     .package(url: "https://github.com/huggingface/swift-huggingface.git", from: "0.9.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(url: "https://github.com/subsriram/VecturaKit.git", branch: "main"),
+    .package(url: "https://github.com/rryam/VecturaKit.git", branch: "main"),
     .package(url: "https://github.com/ml-explore/mlx-swift-lm/", branch: "main"),
     .package(url: "https://github.com/DePasqualeOrg/swift-tokenizers.git", branch: "main"),
     .package(url: "https://github.com/huggingface/swift-huggingface.git", from: "0.9.0"),

--- a/Sources/TestMLXExamples/TestMLXExamples.swift
+++ b/Sources/TestMLXExamples/TestMLXExamples.swift
@@ -28,7 +28,7 @@ struct TestMLXExamples {
     )
     let vectorDB = try await VecturaKit(
       config: config,
-      embedder: try await MLXEmbedder(configuration: .nomic_text_v1_5)
+      embedder: try await MLXEmbedder(configuration: EmbedderRegistry.nomic_text_v1_5)
     )
     debugPrint("MLX Database initialized successfully")
     debugPrint("Document count: \(try await vectorDB.documentCount)")
@@ -103,7 +103,7 @@ struct TestMLXExamples {
       ?? true
     let modeLabel = adaptiveEnabled ? "adaptive" : "single-batch"
 
-    let embedder = try await MLXEmbedder(configuration: .nomic_text_v1_5)
+    let embedder = try await MLXEmbedder(configuration: EmbedderRegistry.nomic_text_v1_5)
     let corpus = makeSyntheticTexts(seed: 20260305, count: 384)
     let iterations = 5
 
@@ -132,7 +132,7 @@ struct TestMLXExamples {
   }
 
   private static func printEmbedding(for text: String) async throws {
-    let embedder = try await MLXEmbedder(configuration: .nomic_text_v1_5)
+    let embedder = try await MLXEmbedder(configuration: EmbedderRegistry.nomic_text_v1_5)
     let vector = try await embedder.embed(text: text)
     let previewCount = min(vector.count, 24)
     let preview = vector.prefix(previewCount)

--- a/Sources/VecturaMLXCLI/VecturaMLXCLI.swift
+++ b/Sources/VecturaMLXCLI/VecturaMLXCLI.swift
@@ -1,6 +1,7 @@
 import ArgumentParser
 import Foundation
 import MLXEmbedders
+import MLXLMCommon
 import VecturaKit
 import VecturaMLXKit
 
@@ -38,7 +39,7 @@ struct VecturaMLXCLI: AsyncParsableCommand {
     dimension: Int? = nil,
     numResults: Int = 10,
     threshold: Float = 0.7,
-    modelConfiguration: MLXEmbedders.ModelConfiguration = .nomic_text_v1_5
+    modelConfiguration: MLXLMCommon.ModelConfiguration = EmbedderRegistry.nomic_text_v1_5
   ) async throws -> VecturaKit {
     let config = try VecturaConfig(
       name: dbName,

--- a/Sources/VecturaMLXKit/MLXEmbedder.swift
+++ b/Sources/VecturaMLXKit/MLXEmbedder.swift
@@ -8,8 +8,8 @@ import VecturaKit
 
 /// An embedder implementation using MLX library for generating vector embeddings.
 public actor MLXEmbedder: VecturaEmbedder {
-  private let modelContainer: MLXEmbedders.ModelContainer
-  private let configuration: MLXEmbedders.ModelConfiguration
+  private let modelContainer: EmbedderModelContainer
+  private let configuration: MLXLMCommon.ModelConfiguration
   private let adaptiveBatchingEnabled: Bool
   private var cachedDimension: Int?
 
@@ -17,10 +17,10 @@ public actor MLXEmbedder: VecturaEmbedder {
   ///
   /// - Parameter configuration: The MLX model configuration to use. Defaults to `.nomic_text_v1_5`.
   /// - Throws: An error if the model container cannot be loaded.
-  public init(configuration: MLXEmbedders.ModelConfiguration = .nomic_text_v1_5) async throws {
+  public init(configuration: MLXLMCommon.ModelConfiguration = EmbedderRegistry.nomic_text_v1_5) async throws {
     self.configuration = configuration
     self.adaptiveBatchingEnabled = Self.resolveAdaptiveBatchingSetting()
-    self.modelContainer = try await MLXEmbedders.loadModelContainer(
+    self.modelContainer = try await EmbedderModelFactory.shared.loadContainer(
       from: HuggingFaceDownloader(),
       using: TransformersTokenizerLoader(),
       configuration: configuration
@@ -61,7 +61,10 @@ public actor MLXEmbedder: VecturaEmbedder {
       }
     }
 
-    return try await modelContainer.perform { (model: EmbeddingModel, tokenizer, pooling) -> [[Float]] in
+    return try await modelContainer.perform { context -> [[Float]] in
+      let model = context.model
+      let tokenizer = context.tokenizer
+      let pooling = context.pooling
       let inputs = texts.map {
         tokenizer.encode(text: $0, addSpecialTokens: true)
       }

--- a/Sources/VecturaMLXKit/MLXEmbedder.swift
+++ b/Sources/VecturaMLXKit/MLXEmbedder.swift
@@ -182,6 +182,7 @@ enum EmbeddingError: Error {
   case unsupportedPoolingShape([Int])
   case vectorCountMismatch(expected: Int, received: Int)
   case invalidRepositoryID(String)
+  case invalidSafeTensorsHeader(URL)
 }
 
 private struct HuggingFaceDownloader: MLXLMCommon.Downloader {
@@ -202,7 +203,7 @@ private struct HuggingFaceDownloader: MLXLMCommon.Downloader {
       throw EmbeddingError.invalidRepositoryID(id)
     }
 
-    return try await client.downloadSnapshot(
+    let snapshot = try await client.downloadSnapshot(
       of: repoID,
       revision: revision ?? "main",
       matching: patterns,
@@ -210,12 +211,129 @@ private struct HuggingFaceDownloader: MLXLMCommon.Downloader {
         progressHandler(progress)
       }
     )
+    return try normalizedNomicSnapshotIfNeeded(snapshot, id: id)
+  }
+
+  private func normalizedNomicSnapshotIfNeeded(_ snapshot: URL, id: String) throws -> URL {
+    let configURL = snapshot.appending(path: "config.json")
+    guard
+      let configData = try? Data(contentsOf: configURL),
+      var config = try JSONSerialization.jsonObject(with: configData) as? [String: Any],
+      config["model_type"] as? String == "nomic_bert",
+      let maxPositionEmbeddings = config["max_position_embeddings"] as? Int,
+      maxPositionEmbeddings > 0
+    else {
+      return snapshot
+    }
+
+    let safeTensorURLs = try snapshot.safeTensorURLs()
+    let hasPositionEmbeddings = try safeTensorURLs.contains { url in
+      try url.safeTensorHeaderContains { key in
+        key.hasSuffix("embeddings.position_embeddings.weight")
+      }
+    }
+    guard !hasPositionEmbeddings else {
+      return snapshot
+    }
+
+    config["max_position_embeddings"] = 0
+    let normalizedSnapshot = Self.normalizedSnapshotURL(snapshot: snapshot, id: id)
+    try FileManager.default.replaceDirectory(at: normalizedSnapshot)
+
+    let contents = try FileManager.default.contentsOfDirectory(
+      at: snapshot,
+      includingPropertiesForKeys: nil,
+      options: [.skipsHiddenFiles]
+    )
+    for sourceURL in contents where sourceURL.lastPathComponent != "config.json" {
+      let destinationURL = normalizedSnapshot.appending(path: sourceURL.lastPathComponent)
+      try FileManager.default.createSymbolicLink(
+        at: destinationURL,
+        withDestinationURL: sourceURL
+      )
+    }
+
+    let normalizedConfigData = try JSONSerialization.data(
+      withJSONObject: config,
+      options: [.prettyPrinted, .sortedKeys]
+    )
+    try normalizedConfigData.write(to: normalizedSnapshot.appending(path: "config.json"))
+    return normalizedSnapshot
+  }
+
+  private static func normalizedSnapshotURL(snapshot: URL, id: String) -> URL {
+    let safeID = id.map { character in
+      character.isLetter || character.isNumber ? character : "-"
+    }.reduce(into: "") { result, character in
+      result.append(character)
+    }
+    return FileManager.default.temporaryDirectory
+      .appending(path: "VecturaMLXKit")
+      .appending(path: "NormalizedSnapshots")
+      .appending(path: "\(safeID)-\(snapshot.lastPathComponent)")
+  }
+}
+
+private extension FileManager {
+  func replaceDirectory(at url: URL) throws {
+    if fileExists(atPath: url.path) {
+      try removeItem(at: url)
+    }
+    try createDirectory(at: url, withIntermediateDirectories: true)
+  }
+}
+
+private extension URL {
+  func safeTensorURLs() throws -> [URL] {
+    guard let enumerator = FileManager.default.enumerator(
+      at: self,
+      includingPropertiesForKeys: [.isRegularFileKey, .isSymbolicLinkKey],
+      options: [.skipsHiddenFiles]
+    ) else {
+      return []
+    }
+
+    return enumerator.compactMap { item in
+      guard let url = item as? URL, url.pathExtension == "safetensors" else {
+        return nil
+      }
+      return url
+    }
+  }
+
+  func safeTensorHeaderContains(_ predicate: (String) throws -> Bool) throws -> Bool {
+    let handle = try FileHandle(forReadingFrom: self)
+    defer {
+      try? handle.close()
+    }
+
+    guard let lengthData = try handle.read(upToCount: 8), lengthData.count == 8 else {
+      throw EmbeddingError.invalidSafeTensorsHeader(self)
+    }
+
+    let headerLength = lengthData.enumerated().reduce(UInt64(0)) { partialResult, element in
+      partialResult | (UInt64(element.element) << UInt64(element.offset * 8))
+    }
+    guard headerLength <= UInt64(Int.max),
+      let headerData = try handle.read(upToCount: Int(headerLength)),
+      headerData.count == Int(headerLength),
+      let header = try JSONSerialization.jsonObject(with: headerData) as? [String: Any]
+    else {
+      throw EmbeddingError.invalidSafeTensorsHeader(self)
+    }
+
+    for key in header.keys where key != "__metadata__" {
+      if try predicate(key) {
+        return true
+      }
+    }
+    return false
   }
 }
 
 private struct TransformersTokenizerLoader: MLXLMCommon.TokenizerLoader {
   func load(from directory: URL) async throws -> any MLXLMCommon.Tokenizer {
-    let upstream = try await AutoTokenizer.from(modelFolder: directory)
+    let upstream = try await AutoTokenizer.from(directory: directory)
     return HuggingFaceTokenizerBridge(upstream)
   }
 }
@@ -232,7 +350,7 @@ private struct HuggingFaceTokenizerBridge: MLXLMCommon.Tokenizer {
   }
 
   func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
-    upstream.decode(tokens: tokenIds, skipSpecialTokens: skipSpecialTokens)
+    upstream.decode(tokenIds: tokenIds, skipSpecialTokens: skipSpecialTokens)
   }
 
   func convertTokenToId(_ token: String) -> Int? {

--- a/Tests/VecturaMLXKitTests/VecturaMLXKitTests.swift
+++ b/Tests/VecturaMLXKitTests/VecturaMLXKitTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Metal
 import MLX
+import MLXEmbedders
 import Testing
 @testable import VecturaMLXKit
 @testable import VecturaKit
@@ -71,7 +72,7 @@ struct VecturaMLXKitTests {
     }
 
     do {
-      let embedder = try await MLXEmbedder(configuration: .nomic_text_v1_5)
+      let embedder = try await MLXEmbedder(configuration: EmbedderRegistry.nomic_text_v1_5)
       return try await VecturaKit(config: config, embedder: embedder)
     } catch {
       return nil


### PR DESCRIPTION
## Summary

Updates VecturaMLXKit for the current mlx-swift-lm APIs and keeps the package dependency aligned with upstream VecturaKit.

- switches the VecturaKit dependency back to https://github.com/rryam/VecturaKit.git and repins Package.resolved to upstream main
- adapts the MLX embedder loader/tokenizer path for the latest mlx-swift-lm split APIs
- adds adaptive token-length batching support, tokenizer padding fallbacks, and runtime benchmark coverage

## Validation

- swift build
- swift test --no-parallel
- xcrun --find metal
- xcrun --find metallib
- xcodebuild -scheme vectura-mlx-cli -destination 'platform=macOS' -derivedDataPath /tmp/VecturaMLXKit-xc build\n- find /tmp/VecturaMLXKit-xc/Build/Products/Debug -name default.metallib\n- /tmp/VecturaMLXKit-xc/Build/Products/Debug/vectura-mlx-cli mock --db-name qa-db\n- VECTURA_MLX_ADAPTIVE_BATCHING=0 /tmp/VecturaMLXKit-xc/Build/Products/Debug/vectura-mlx-cli mock --db-name qa-db-off\n- VECTURA_MLX_ADAPTIVE_BATCHING=1 /tmp/VecturaMLXKit-xc/Build/Products/Debug/vectura-mlx-cli mock --db-name qa-db-on-seq\n- MLX_RUNTIME_BENCH=1 VECTURA_MLX_ADAPTIVE_BATCHING=0 /tmp/VecturaMLXKit-xc/Build/Products/Debug/TestMLXExamples\n- MLX_RUNTIME_BENCH=1 VECTURA_MLX_ADAPTIVE_BATCHING=1 /tmp/VecturaMLXKit-xc/Build/Products/Debug/TestMLXExamples\n\n## Notes\n\nThe first adaptive-on smoke run was attempted concurrently with the adaptive-off run and failed while removing a cached model directory. Rerunning the adaptive-on smoke test sequentially with a fresh database name passed.