### PR TITLE
Fix regression: add missing `try` inside throwing tokenizer closures

### DIFF
--- a/Sources/VecturaMLXKit/MLXEmbedder.swift
+++ b/Sources/VecturaMLXKit/MLXEmbedder.swift
@@ -353,7 +353,7 @@ private struct HuggingFaceTokenizerBridge: MLXLMCommon.Tokenizer {
     // protocol this bridge conforms to is non-throwing, so absorb the error and
     // fall back to an empty token list.
     let encode: () throws -> [Int] = {
-      upstream.encode(text: text, addSpecialTokens: addSpecialTokens)
+      try upstream.encode(text: text, addSpecialTokens: addSpecialTokens)
     }
     return (try? encode()) ?? []
   }
@@ -362,7 +362,7 @@ private struct HuggingFaceTokenizerBridge: MLXLMCommon.Tokenizer {
     // See note in `encode(text:addSpecialTokens:)`: bridge a throwing upstream
     // call into the non-throwing protocol requirement.
     let decode: () throws -> String = {
-      upstream.decode(tokenIds: tokenIds, skipSpecialTokens: skipSpecialTokens)
+      try upstream.decode(tokenIds: tokenIds, skipSpecialTokens: skipSpecialTokens)
     }
     return (try? decode()) ?? ""
   }


### PR DESCRIPTION
## Problem

Follow-up to #7. The "Polish tokenizer bridge compatibility" commit reworked the bridge into closure form:

```swift
let encode: () throws -> [Int] = {
  upstream.encode(text: text, addSpecialTokens: addSpecialTokens)
}
return (try? encode()) ?? []
```

A `throws` closure **type** does not implicitly add `try` to throwing calls in its body. Against current `swift-transformers` (where `Tokenizer.encode/decode` throw), `main` therefore no longer compiles:

```
Sources/VecturaMLXKit/MLXEmbedder.swift:356:7: error: call can throw, but it is not marked with 'try' and the error is not handled
Sources/VecturaMLXKit/MLXEmbedder.swift:365:7: error: call can throw, but it is not marked with 'try' and the error is not handled
```

## Fix

Add `try` inside both closures. This compiles against the throwing API, and stays compatible with older non-throwing `swift-transformers` versions (there it's only a benign "no calls to throwing functions occur within 'try'" warning, not an error) — preserving the portability the closure form was aiming for.

## Verification

Pinned a downstream app (Xcode/SwiftPM) to this branch: full build `** BUILD SUCCEEDED **`, `MLXEmbedder.swift` compiles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)